### PR TITLE
fix: script fails on small screens

### DIFF
--- a/tweetXer.js
+++ b/tweetXer.js
@@ -177,7 +177,7 @@ var TweetsXer = {
     },
 
     createUploadForm() {
-        var h2_class = document.querySelectorAll("h2")[1].getAttribute("class")
+        var h2_class = document.querySelectorAll("h2")[1]?.getAttribute("class") || ""
         var div = document.createElement("div")
         div.id = this.dId
         if (document.getElementById(this.dId))


### PR DESCRIPTION
Currently, when the script is run on a small screen device (breakpoint seems to be around 985px viewport width – so this can already happen on many laptops, when the Developer Tools are opened on the right/left side of the screen), there will be no h2 element to get the CSS classes from (Twitter dynamically adds/removes the sidebar boxes with this specific h2 on small screens), so the script will fail with this error:

```
Uncaught TypeError: can't access property "getAttribute", document.querySelectorAll(...)[1] is undefined
```

I've added the optional chaining operator and a default value (empty string), so it will still work (even though the headline won't look very beautiful) and not break.