### PR TITLE
Fix error handling, add resume feature and skip counter

### DIFF
--- a/tweetXer.js
+++ b/tweetXer.js
@@ -723,7 +723,7 @@
 
         async slowDelete() {
             //document.getElementById("toggleAdvanced").click()
-            document.getElementById('start').remove()
+            document.getElementById('start')?.remove()
             TweetsXer.total = TweetsXer.TweetCount
             TweetsXer.createProgressBar()
 


### PR DESCRIPTION
## Summary

- **Fix `error.Name` typo** → `error.name` (the catch block for AbortError/TimeoutError never matched)
- **Fix 429 rate limit handling**: use `x-rate-limit-reset` header to wait the correct duration instead of only 1 second
- **Fix missing `resolve()` calls** on 429 and non-200 responses that caused the Promise to hang indefinitely, stalling the entire deletion process
- **Add resume feature**: progress is saved to `localStorage` periodically, so deletion can be resumed after browser close, crash, or rate limit interruption
- **Add skip counter**: separately tracks items that returned non-200 (e.g., 404 already deleted), so users can see how many were actually deleted vs. skipped
- **Remove unreliable auto-skip calculation**: the old heuristic (`total - profileCount - 5%`) could skip too many or too few tweets; users can still manually set a skip count via Advanced Options

## Details

### Bug fixes

The original `sendRequest()` had three critical issues:

1. `error.Name === 'AbortError'` — JavaScript property names are case-sensitive, so this never matches. Fixed to `error.name === 'AbortError' || error.name === 'TimeoutError'`.

2. When receiving a 429 status, the code only waited 1 second and didn't call `resolve()`, causing the wrapping Promise to never settle. Now it reads `x-rate-limit-reset` and waits appropriately (minimum 30s, fallback 60s if header missing), then resolves.

3. Non-200/non-429 responses (e.g., 404 for already-deleted tweets) also didn't call `resolve()`, hanging the script. Now they increment a skip counter and resolve.

### Resume feature

- Progress (remaining IDs, counts, action type) is saved to `localStorage` every 50 deletions and on rate limit events
- On page load, if saved progress is found, a banner offers to **Resume** or **Discard and start over**
- On completion, saved progress is automatically cleared

### Skip counter

- `sCount` tracks items that returned non-200 (already deleted, etc.)
- Progress bar reflects `dCount + sCount` so it reaches 100% correctly
- Completion message shows both counts: "Done! X deleted / Y skipped"

## Test plan

- [ ] Load the script on x.com profile page, verify the UI appears correctly
- [ ] Upload a `tweet-headers.js` file and verify deletion starts with progress saving
- [ ] Interrupt mid-deletion (close tab), reopen, verify resume banner appears
- [ ] Click "Resume" and verify it continues from where it left off
- [ ] Click "Discard and start over" and verify progress is cleared
- [ ] Verify 429 responses are handled with proper wait time (check console logs)
- [ ] Verify already-deleted tweets (404) are counted as "skipped" not "deleted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)